### PR TITLE
[7.0] invoice prorata delay

### DIFF
--- a/contract_isp_invoice/__openerp__.py
+++ b/contract_isp_invoice/__openerp__.py
@@ -44,8 +44,12 @@ Features:
         'security/ir.model.access.csv',
         'contract_isp_invoice_data.xml',
         'contract_isp_invoice_view.xml',
+        'view_company.xml',
         'wizard/contract_isp_invoice_invoice_create.xml',
         'wizard/close_contract_view.xml'
+    ],
+    'demo': [
+        'demo_security.xml',
     ],
     'active': False,
     'installable': True,

--- a/contract_isp_invoice/company.py
+++ b/contract_isp_invoice/company.py
@@ -32,9 +32,18 @@ class Company(orm.Model):
     _columns = {
         'invoice_day': fields.selection(_days, 'Invoice day'),
         'billing_day': fields.selection(_days, 'Billing day'),
-        'send_email_contract_invoice': fields.boolean('Send invoice by email')
+        'send_email_contract_invoice': fields.boolean('Send invoice by email'),
+        'prorata_bill_delay': fields.integer('Prorata Invoice delay minutes'),
     }
 
     _defaults = {
         'send_email_contract_invoice': True
     }
+
+    def get_prorata_bill_delay(self, cr, uid, company_id=None, context=None):
+        if company_id:
+            company = self.browse(cr, uid, company_id)
+        else:
+            company = self.pool["res.users"].browse(cr, uid, uid).company_id
+
+        return company.prorata_bill_delay or 0

--- a/contract_isp_invoice/contract.py
+++ b/contract_isp_invoice/contract.py
@@ -1061,7 +1061,8 @@ class PendingInvoice(orm.Model):
         'context': _save_context,
     }
 
-    def trigger_or_invoice(self, cr, uid, contract_id, source_process, context=None):
+    def trigger_or_invoice(self, cr, uid, contract_id, source_process,
+                           context=None):
         bill_delay = self.pool["res.company"].get_prorata_bill_delay(
             cr, uid, context=context)
 
@@ -1072,7 +1073,6 @@ class PendingInvoice(orm.Model):
                 cr, uid, contract_id,
                 source_process=source_process,
                 context=context)
-
 
     def trigger(self, cr, uid, contract_id, source_process, context=None):
         """ Trigger the invoicing for a contract and return the trigger id """
@@ -1114,8 +1114,8 @@ class PendingInvoice(orm.Model):
 
         return res
 
-
-    def cron_send_pending(self, cr, uid, curtime=None, autocommit=True, context=None):
+    def cron_send_pending(self, cr, uid, curtime=None, autocommit=True,
+                          context=None):
         """
         Send pending invoices that have gone through the grace delay
 

--- a/contract_isp_invoice/contract_isp_invoice_data.xml
+++ b/contract_isp_invoice/contract_isp_invoice_data.xml
@@ -11,6 +11,17 @@
             <field eval="-1" name="days2"/>
             <field eval="account_payment_term_end_of_month" name="payment_id"/>
         </record>
+        <record model="ir.cron" id="account_analytic_cron">
+            <field name="name">Contract ProRata Invoicing</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">minutes</field>
+            <field name="numbercall">-1</field>
+            <field name="active" eval="True" />
+            <field name="doall" eval="False"/>
+            <field name="model" eval="'contract.pending.invoice'"/>
+            <field name="function" eval="'cron_send_pending'"/>
+            <field name="args" eval="'()'" />
+        </record>
     </data>
 
     <data noupdate="1">

--- a/contract_isp_invoice/contract_isp_invoice_view.xml
+++ b/contract_isp_invoice/contract_isp_invoice_view.xml
@@ -1,18 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openerp>
     <data>
-        <record id="view_company_contract_isp_invoice_form" model="ir.ui.view">
-            <field name="name">contract.isp.invoice.res.company.form</field>
-            <field name="model">res.company</field>
-            <field name="inherit_id" ref="contract_isp.view_company_contract_isp_form"/>
-            <field name="arch" type="xml">
-                <field name="cutoff_day" position="after">
-                    <field name="invoice_day" />
-                    <field name="send_email_contract_invoice" />
-                </field>
-            </field>
-        </record>
-
         <record id="contract_isp_form_button1" model="ir.ui.view">
             <field name="name">contract.isp.form.button1</field>
             <field name="model">account.analytic.account</field>

--- a/contract_isp_invoice/demo_security.xml
+++ b/contract_isp_invoice/demo_security.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+      <record id="base.user_demo" model="res.users">
+        <field name="groups_id" eval="[(4,ref('contract_isp.group_isp_agent'))]"/> 
+      </record>
+    </data>
+</openerp>

--- a/contract_isp_invoice/security/ir.model.access.csv
+++ b/contract_isp_invoice/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 "access_account_invoice_line_group_isp_agent","account_invoice_line contract_isp.group_isp_agent","account.model_account_invoice_line","contract_isp.group_isp_agent",1,1,1,1
 "access_account_invoice_group_isp_agent","account_invoice contract_isp.group_isp_agent","account.model_account_invoice","contract_isp.group_isp_agent",1,1,1,1
+"access_pending_invoice_group_isp_agent","contract_pending_invoice contract_isp.group_isp_agent","model_contract_pending_invoice","contract_isp.group_isp_agent",1,1,1,0

--- a/contract_isp_invoice/tests/common.py
+++ b/contract_isp_invoice/tests/common.py
@@ -55,7 +55,11 @@ class ServiceSetup(object):
 
     def _configure_company(self):
         self.company = self.company_obj.browse(self.cr, self.uid, 1)
-        self.company.write({"cutoff_day": "7", "invoice_day": "14"})
+        self.company.write({
+            "cutoff_day": "7",
+            "invoice_day": "14",
+            "prorata_bill_delay": 0,
+        })
 
     def _create_partner(self):
         self.partner_id = self.partner_obj.name_create(

--- a/contract_isp_invoice/tests/test_prorata.py
+++ b/contract_isp_invoice/tests/test_prorata.py
@@ -20,10 +20,11 @@
 ##############################################################################
 from __future__ import unicode_literals
 
-from datetime import date
+from datetime import date, datetime, timedelta
 from functools import partial
 
 from openerp.tests.common import TransactionCase
+from openerp.tools import DEFAULT_SERVER_DATETIME_FORMAT
 
 from .common import ServiceSetup, YEAR
 
@@ -189,3 +190,62 @@ class test_prorata_activate_service(TransactionCase, ServiceSetup):
             delta=0.01)
         self.assertEquals(invoice.type, inv_type,
                           msg="Wrong type of invoice/refund")
+
+    def test_bill_delay(self):
+        cr, uid = self.cr, self.ref("base.user_demo")
+        su_uid = self.uid
+
+        self.company.write({"prorata_bill_delay": "5"})
+        act_date = "{0}-05-05".format(YEAR)
+        self.cr.execute(
+            """ SELECT COALESCE(max(id), 0) from account_invoice
+            WHERE partner_id = %s
+            """,
+            (self.partner_id, )
+        )
+        max_invoice = self.cr.fetchone()[0]
+        now = datetime.utcnow()
+        sid = self._create_activate_service(self.p_internet,  act_date)
+        self.wiz_deactivate_obj.deactivate(
+            cr, uid,
+            [self.wiz_deactivate_obj.create(
+                cr, uid, {
+                    "account_id": self.account_id,
+                    "service_id": sid,
+                    "deactivation_date": "{0}-05-06".format(YEAR),
+                })],
+            {'operation_date': date(YEAR, 5, 6)}
+        )
+
+        new_invoices = self.invoice_obj.search(
+            cr, uid, [('partner_id', '=', self.partner_id),
+                      ('id', '>', max_invoice)],
+        )
+        self.assertEquals(new_invoices, [],
+                          "No new invoice expected")
+
+        # Delay is not passed yet, expecting no new invoice
+        self.registry("contract.pending.invoice").cron_send_pending(
+            cr, su_uid, curtime=now.strftime(DEFAULT_SERVER_DATETIME_FORMAT))
+
+        new_invoices = self.invoice_obj.search(
+            cr, su_uid, [('partner_id', '=', self.partner_id),
+                      ('id', '>', max_invoice)],
+        )
+        self.assertEquals(new_invoices, [],
+                          "No new invoice expected")
+
+
+        self.registry("contract.pending.invoice").cron_send_pending(
+            cr, su_uid, curtime=(
+                now + timedelta(minutes=6)
+            ).strftime(DEFAULT_SERVER_DATETIME_FORMAT),
+            autocommit=False,
+        )
+
+        new_invoices = self.invoice_obj.search(
+            cr, su_uid, [('partner_id', '=', self.partner_id),
+                      ('id', '>', max_invoice)],
+        )
+        self.assertEquals(len(new_invoices), 1,
+                          "One new invoice expected")

--- a/contract_isp_invoice/tests/test_prorata.py
+++ b/contract_isp_invoice/tests/test_prorata.py
@@ -205,7 +205,7 @@ class test_prorata_activate_service(TransactionCase, ServiceSetup):
         )
         max_invoice = self.cr.fetchone()[0]
         now = datetime.utcnow()
-        sid = self._create_activate_service(self.p_internet,  act_date)
+        sid = self._create_activate_service(self.p_internet, act_date)
         self.wiz_deactivate_obj.deactivate(
             cr, uid,
             [self.wiz_deactivate_obj.create(
@@ -230,11 +230,10 @@ class test_prorata_activate_service(TransactionCase, ServiceSetup):
 
         new_invoices = self.invoice_obj.search(
             cr, su_uid, [('partner_id', '=', self.partner_id),
-                      ('id', '>', max_invoice)],
+                         ('id', '>', max_invoice)],
         )
         self.assertEquals(new_invoices, [],
                           "No new invoice expected")
-
 
         self.registry("contract.pending.invoice").cron_send_pending(
             cr, su_uid, curtime=(
@@ -245,7 +244,7 @@ class test_prorata_activate_service(TransactionCase, ServiceSetup):
 
         new_invoices = self.invoice_obj.search(
             cr, su_uid, [('partner_id', '=', self.partner_id),
-                      ('id', '>', max_invoice)],
+                         ('id', '>', max_invoice)],
         )
         self.assertEquals(len(new_invoices), 1,
                           "One new invoice expected")

--- a/contract_isp_invoice/view_company.xml
+++ b/contract_isp_invoice/view_company.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+  <data>
+    <record id="view_company_contract_isp_invoice_form" model="ir.ui.view">
+      <field name="name">contract.isp.invoice.res.company.form</field>
+      <field name="model">res.company</field>
+      <field name="inherit_id" ref="contract_isp.view_company_contract_isp_form"/>
+      <field name="arch" type="xml">
+        <field name="cutoff_day" position="after">
+          <field name="invoice_day" />
+          <field name="prorata_bill_delay" />
+          <field name="send_email_contract_invoice" />
+        </field>
+      </field>
+    </record>
+  </data>
+</openerp>

--- a/contract_isp_invoice/wizard/activate_contract_service.py
+++ b/contract_isp_invoice/wizard/activate_contract_service.py
@@ -37,12 +37,12 @@ class contract_service_activate(orm.TransientModel):
                                                               ids,
                                                               context=context)
 
-        account_analytic_account_obj = self.pool['account.analytic.account']
-
-        account_analytic_account_obj.create_invoice(
-            cr, uid, wizard.account_id.id,
+        self.pool["contract.pending.invoice"].trigger_or_invoice(
+            cr, uid,
+            contract_id=wizard.account_id.id,
             source_process=PROCESS_PRORATA,
-            context=context)
+            context=context,
+        )
 
         return ret
 
@@ -59,11 +59,11 @@ class contract_service_deactivate(orm.TransientModel):
         ret = super(contract_service_deactivate, self).deactivate(
             cr, uid, ids, context=context)
 
-        account_analytic_account_obj = self.pool['account.analytic.account']
-
-        account_analytic_account_obj.create_invoice(
-            cr, uid, wizard.account_id.id,
+        self.pool["contract.pending.invoice"].trigger_or_invoice(
+            cr, uid,
+            contract_id=wizard.account_id.id,
             source_process=PROCESS_PRORATA,
-            context=context)
+            context=context,
+        )
 
         return ret


### PR DESCRIPTION
This PR adds a new setting on the company "prorata_bill_delay", which allows delaying the sending of invoices when activating or deactivating services. Currently, invoices are sent for each operation, leading to clients receiving many invoices in a small time window.
With this change, invoices are delayed so they can be grouped.
