### PR TITLE
[FIX] reseller invoice merging leaves analytic lines "to be invoiced"

### DIFF
--- a/contract_isp_invoice/contract.py
+++ b/contract_isp_invoice/contract.py
@@ -504,6 +504,15 @@ class account_analytic_account(orm.Model):
                 account_invoice_line_obj.write(
                     cr, uid, line_ids, {'invoice_id': inv[0]},
                     context=context)
+                # Assign analytic lines to first invoice
+                cr.execute(
+                    """
+                    UPDATE account_analytic_line
+                    SET invoice_id = %s
+                    WHERE invoice_id IN %s
+                    """,
+                    (inv[0], inv[1:]),
+                )
                 account_invoice_obj.button_compute(
                     cr, uid, [inv[0]], context=context)
                 account_invoice_obj.unlink(cr, uid, inv[1:], context=context)

--- a/contract_isp_invoice/contract.py
+++ b/contract_isp_invoice/contract.py
@@ -511,7 +511,7 @@ class account_analytic_account(orm.Model):
                     SET invoice_id = %s
                     WHERE invoice_id IN %s
                     """,
-                    (inv[0], inv[1:]),
+                    (inv[0], tuple(inv[1:])),
                 )
                 account_invoice_obj.button_compute(
                     cr, uid, [inv[0]], context=context)


### PR DESCRIPTION
This fixes a bug where, when billing multiple clients for a reseller, lines for all but one of the reseller clients would be left "to invoice". The analytic lines were losing their invoice_id (on delete set null) when the extra invoices are merged.
