### PR TITLE
[ADD] Enforce unique product codes on contracts

### DIFF
--- a/contract_isp_unique_product/__init__.py
+++ b/contract_isp_unique_product/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import contract

--- a/contract_isp_unique_product/__openerp__.py
+++ b/contract_isp_unique_product/__openerp__.py
@@ -23,8 +23,8 @@
 {
     'name': 'Contract ISP - Unique Product in Contract',
     'version': '0.1',
-    'author': 'Savoir-faire Linux',
-    'maintainer': 'Savoir-faire Linux',
+    'author': "Savoir-faire Linux,Odoo Community Association (OCA)",
+    'maintainer': 'Odoo Community Association (OCA)',
     'website': 'http://www.savoirfairelinux.com',
     'license': 'AGPL-3',
     'category': 'Contract Manage',

--- a/contract_isp_unique_product/__openerp__.py
+++ b/contract_isp_unique_product/__openerp__.py
@@ -1,0 +1,52 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Contract ISP - Unique Product in Contract',
+    'version': '0.1',
+    'author': 'Savoir-faire Linux',
+    'maintainer': 'Savoir-faire Linux',
+    'website': 'http://www.savoirfairelinux.com',
+    'license': 'AGPL-3',
+    'category': 'Contract Manage',
+    'summary': 'Selectively enforce unique product lines in contracts',
+    'description': """
+This module prevents creating or updating contracts with multiple services
+with the same product code.
+
+Contributors
+------------
+* Vincent Vinet (vincent.vinet@savoirfairelinux.com)
+""",
+    'depends': [
+        'contract_isp',
+    ],
+    'external_dependencies': {
+        'python': [],
+    },
+    'data': [
+    ],
+    'demo': [],
+    'test': [],
+    'installable': True,
+    'auto_install': False,
+}

--- a/contract_isp_unique_product/__openerp__.py
+++ b/contract_isp_unique_product/__openerp__.py
@@ -44,6 +44,7 @@ Contributors
         'python': [],
     },
     'data': [
+        'contract_view.xml',
     ],
     'demo': [],
     'test': [],

--- a/contract_isp_unique_product/contract.py
+++ b/contract_isp_unique_product/contract.py
@@ -25,12 +25,7 @@ from openerp.tools.translate import _
 
 
 def unique(values):
-    seen = set()
-    for v in values:
-        if v in seen:
-            return False
-        seen.add(v)
-    return True
+    return len(values) == len(set(values))
 
 
 class Contract(orm.Model):

--- a/contract_isp_unique_product/contract.py
+++ b/contract_isp_unique_product/contract.py
@@ -1,0 +1,91 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2015 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import fields, orm
+from openerp.tools.translate import _
+
+
+def unique(values):
+    seen = set()
+    for v in values:
+        if v in seen:
+            return False
+        seen.add(v)
+    return True
+
+
+class Contract(orm.Model):
+    _inherit = 'account.analytic.account'
+
+    def _get_has_unique_products(self, cr, uid, ids, field_name, arg, context):
+        res = {}
+        for contract in self.browse(cr, uid, ids, context=context):
+            res[contract.id] = not unique(
+                cs.product_id.default_code
+                for cs in contract.contract_service_ids
+                if cs.product_id.default_code
+            )
+        return res
+
+    _columns = {
+        'has_duplicate_products': fields.function(
+            _get_has_unique_products,
+            type="bool",
+            store=False,
+        ),
+    }
+
+    def _check_unique_products(self, cr, uid, ids, context=None):
+        if isinstance(ids, (int, long)):
+            ids = [ids]
+        for contract in self.browse(cr, uid, ids, context=context):
+            if contract.has_duplicate_products:
+                raise orm.except_orm(
+                    _("Validation Error"),
+                    _("You are not allowed to have multiple identical "
+                      "products in a contract"),
+                )
+
+    def create(self, cr, uid, values, context=None):
+        # Do it simple, check after creation
+        res = super(Contract, self).create(cr, uid, values, context=context)
+        self._check_unique_products(cr, uid, res)
+        return res
+
+    def write(self, cr, uid, ids, values, context=None):
+        res = super(Contract, self).write(cr, uid, ids, values,
+                                          context=context)
+        if "contract_service_ids" in values:
+            self._check_unique_products(cr, uid, ids, context=context)
+        return res
+
+
+class ContractService(orm.Model):
+    _inherit = 'contract.service'
+
+    def create(self, cr, uid, values, context=None):
+        res = super(ContractService, self).create(cr, uid, values,
+                                                  context=context)
+        if "account_id" in values:
+            self.pool["account.analytic.account"]._check_unique_products(
+                cr, uid, values["account_id"], context=context)
+        return res

--- a/contract_isp_unique_product/contract.py
+++ b/contract_isp_unique_product/contract.py
@@ -25,6 +25,8 @@ from openerp.tools.translate import _
 
 
 def unique(values):
+    if iter(values) is values:
+        values = list(values)
     return len(values) == len(set(values))
 
 

--- a/contract_isp_unique_product/contract_view.xml
+++ b/contract_isp_unique_product/contract_view.xml
@@ -43,7 +43,7 @@
       <field name="inherit_id" ref="contract_isp.view_contract_isp_form" />
       <field name="arch" type="xml">
         <xpath expr="//button[@string='Desactivate']" position="after">
-          <field name="is_duplicate" invisible="1" />
+          <field name="is_duplicate" invisible="1" widget="boolean" />
           <button
             name="%(action_view_contract_service_delete)s"
             string="Delete"

--- a/contract_isp_unique_product/contract_view.xml
+++ b/contract_isp_unique_product/contract_view.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+  <data>
+    <record id="view_contract_service_delete" model="ir.ui.view">
+      <field name="name">Delete Service</field>
+      <field name="model">contract.service.delete</field>
+      <field name="arch" type="xml">
+        <form string="Delete Service" version="7.0">
+          <group>
+            <field nolabel="1" name="message" readonly="1"/>
+            <field name="account_id" invisible="1" />
+            <field name="service_id" invisible="1" />
+          </group>
+          <footer>
+            <button
+              name="delete"
+              string="Delete"
+              type="object"
+              class="oe_highlight" />
+            <button
+              string="Cancel"
+              class="oe_link"
+              special="cancel" />
+          </footer>
+        </form>
+      </field>
+    </record>
+
+    <record id="action_view_contract_service_delete" model="ir.actions.act_window">
+      <field name="name">Delete Service</field>
+      <field name="type">ir.actions.act_window</field>
+      <field name="src_model">contract.service</field>
+      <field name="res_model">contract.service.delete</field>
+      <field name="view_type">form</field>
+      <field name="view_mode">form</field>
+      <field name="context">{'default_service_id': active_id}</field>
+      <field name="target">new</field>
+    </record>
+
+    <record id="view_contract_isp_form" model="ir.ui.view">
+      <field name="name">contract.isp.form</field>
+      <field name="model">account.analytic.account</field>
+      <field name="inherit_id" ref="contract_isp.view_contract_isp_form" />
+      <field name="arch" type="xml">
+        <xpath expr="//button[@string='Desactivate']" position="after">
+          <field name="is_duplicate" invisible="1" />
+          <button
+            name="%(action_view_contract_service_delete)s"
+            string="Delete"
+            icon="gtk-delete"
+            type="action"
+            groups="contract_isp.group_isp_agent"
+            attrs="{'invisible': [('is_duplicate', '=', False)]}" />
+        </xpath>
+      </field>
+    </record>
+  </data>
+</openerp>
+

--- a/contract_isp_unique_product/i18n/contract_isp_unique_product.pot
+++ b/contract_isp_unique_product/i18n/contract_isp_unique_product.pot
@@ -1,0 +1,94 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* contract_isp_unique_product
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-06-05 16:01+0000\n"
+"PO-Revision-Date: 2015-06-05 16:01+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: contract_isp_unique_product
+#: field:contract.service.delete,account_id:0
+msgid "Account"
+msgstr ""
+
+#. module: contract_isp_unique_product
+#: code:_description:0
+#: model:ir.model,name:contract_isp_unique_product.model_account_analytic_account
+#, python-format
+msgid "Analytic Account"
+msgstr ""
+
+#. module: contract_isp_unique_product
+#: view:contract.service.delete:0
+msgid "Cancel"
+msgstr ""
+
+#. module: contract_isp_unique_product
+#: view:account.analytic.account:0
+#: view:contract.service.delete:0
+msgid "Delete"
+msgstr ""
+
+#. module: contract_isp_unique_product
+#: view:contract.service.delete:0
+#: model:ir.actions.act_window,name:contract_isp_unique_product.action_view_contract_service_delete
+msgid "Delete Service"
+msgstr ""
+
+#. module: contract_isp_unique_product
+#: field:contract.service.delete,message:0
+msgid "Message"
+msgstr ""
+
+#. module: contract_isp_unique_product
+#: field:contract.service.delete,service_id:0
+msgid "Service"
+msgstr ""
+
+#. module: contract_isp_unique_product
+#: code:addons/contract_isp_unique_product/contract.py:61
+#, python-format
+msgid "Validation Error"
+msgstr ""
+
+#. module: contract_isp_unique_product
+#: code:addons/contract_isp_unique_product/wizard/delete_contract_service.py:44
+#, python-format
+msgid "When deleting a duplicate service, make sure you are deleting the inactive one"
+msgstr ""
+
+#. module: contract_isp_unique_product
+#: code:addons/contract_isp_unique_product/contract.py:62
+#, python-format
+msgid "You are not allowed to have multiple identical products in a contract, remove the inactive duplicate services first."
+msgstr ""
+
+#. module: contract_isp_unique_product
+#: code:_description:0
+#: model:ir.model,name:contract_isp_unique_product.model_contract_service
+#, python-format
+msgid "contract.service"
+msgstr ""
+
+#. module: contract_isp_unique_product
+#: code:_description:0
+#: model:ir.model,name:contract_isp_unique_product.model_contract_service_delete
+#, python-format
+msgid "contract.service.delete"
+msgstr ""
+
+#. module: contract_isp_unique_product
+#: field:account.analytic.account,has_duplicate_products:0
+#: field:contract.service,is_duplicate:0
+msgid "unknown"
+msgstr ""
+

--- a/contract_isp_unique_product/i18n/fr.po
+++ b/contract_isp_unique_product/i18n/fr.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: OpenERP Server 7.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2015-06-05 16:01+0000\n"
-"PO-Revision-Date: 2015-06-05 05:49-0500\n"
+"PO-Revision-Date: 2015-06-05 15:27-0500\n"
 "Last-Translator: Vincent Vinet <vincent.vinet@savoirfairelinux.com>\n"
 "Language-Team: \n"
 "Language: fr_CA\n"
@@ -66,16 +66,18 @@ msgstr "Erreur de validation"
 msgid ""
 "When deleting a duplicate service, make sure you are deleting the inactive "
 "one"
-msgstr "Lorsque vous effacez un service en double, assurez vous de supprimer "
-"le service inactif"
+msgstr ""
+"Lorsque vous effacez un service en double, assurez vous de supprimer le "
+"service inactif"
 
 #. module: contract_isp_unique_product
 #: code:addons/contract_isp_unique_product/contract.py:62
 msgid ""
 "You are not allowed to have multiple identical products in a contract, "
 "remove the inactive duplicate services first."
-msgstr "Il est interdit d'avoir plusieurs fois le même produit dans un contrat "
-", veuillez supprimer les services, en débutant par les inactifs."
+msgstr ""
+"Il est interdit d'avoir plusieurs fois le même produit dans un contrat , "
+"veuillez supprimer les services, en débutant par les inactifs."
 
 #. module: contract_isp_unique_product
 #: code:_description:0

--- a/contract_isp_unique_product/i18n/fr.po
+++ b/contract_isp_unique_product/i18n/fr.po
@@ -1,0 +1,98 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+# 	* contract_isp_unique_product
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-06-05 16:01+0000\n"
+"PO-Revision-Date: 2015-06-05 05:49-0500\n"
+"Last-Translator: Vincent Vinet <vincent.vinet@savoirfairelinux.com>\n"
+"Language-Team: \n"
+"Language: fr_CA\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: contract_isp_unique_product
+#: field:contract.service.delete,account_id:0
+msgid "Account"
+msgstr "Compte Analytique"
+
+#. module: contract_isp_unique_product
+#: code:_description:0
+#: model:ir.model,name:contract_isp_unique_product.model_account_analytic_account
+#, python-format
+msgid "Analytic Account"
+msgstr "Compte Analytique"
+
+#. module: contract_isp_unique_product
+#: view:contract.service.delete:0
+msgid "Cancel"
+msgstr "Annuler"
+
+#. module: contract_isp_unique_product
+#: view:account.analytic.account:0 view:contract.service.delete:0
+msgid "Delete"
+msgstr "Supprimer"
+
+#. module: contract_isp_unique_product
+#: view:contract.service.delete:0
+#: model:ir.actions.act_window,name:contract_isp_unique_product.action_view_contract_service_delete
+msgid "Delete Service"
+msgstr "Suppression de service"
+
+#. module: contract_isp_unique_product
+#: field:contract.service.delete,message:0
+msgid "Message"
+msgstr "Message"
+
+#. module: contract_isp_unique_product
+#: field:contract.service.delete,service_id:0
+msgid "Service"
+msgstr "Services"
+
+#. module: contract_isp_unique_product
+#: code:addons/contract_isp_unique_product/contract.py:61
+#, python-format
+msgid "Validation Error"
+msgstr "Erreur de validation"
+
+#. module: contract_isp_unique_product
+#: code:addons/contract_isp_unique_product/wizard/delete_contract_service.py:44
+#, python-format
+msgid ""
+"When deleting a duplicate service, make sure you are deleting the inactive "
+"one"
+msgstr "Lorsque vous effacez un service en double, assurez vous de supprimer "
+"le service inactif"
+
+#. module: contract_isp_unique_product
+#: code:addons/contract_isp_unique_product/contract.py:62
+msgid ""
+"You are not allowed to have multiple identical products in a contract, "
+"remove the inactive duplicate services first."
+msgstr "Il est interdit d'avoir plusieurs fois le même produit dans un contrat "
+", veuillez supprimer les services, en débutant par les inactifs."
+
+#. module: contract_isp_unique_product
+#: code:_description:0
+#: model:ir.model,name:contract_isp_unique_product.model_contract_service
+#, python-format
+msgid "contract.service"
+msgstr ""
+
+#. module: contract_isp_unique_product
+#: code:_description:0
+#: model:ir.model,name:contract_isp_unique_product.model_contract_service_delete
+#, python-format
+msgid "contract.service.delete"
+msgstr ""
+
+#. module: contract_isp_unique_product
+#: field:account.analytic.account,has_duplicate_products:0
+#: field:contract.service,is_duplicate:0
+msgid "unknown"
+msgstr "inconnu"

--- a/contract_isp_unique_product/wizard/__init__.py
+++ b/contract_isp_unique_product/wizard/__init__.py
@@ -1,9 +1,9 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
+
 ##############################################################################
 #
 #    OpenERP, Open Source Management Solution
-#    This module copyright (C) 2015 Savoir-faire Linux
-#    (<http://www.savoirfairelinux.com>).
+#    Copyright (C) 2013 Savoir-faire Linux (<www.savoirfairelinux.com>).
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -20,5 +20,4 @@
 #
 ##############################################################################
 
-from . import contract
-from . import wizard
+from . import delete_contract_service

--- a/contract_isp_unique_product/wizard/delete_contract_service.py
+++ b/contract_isp_unique_product/wizard/delete_contract_service.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2013 Savoir-faire Linux (<www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.tools.translate import _
+from openerp.osv import orm, fields
+
+from openerp.addons.contract_isp.wizard.activate_contract_service import (
+    _get_account_id,
+    _get_service_id,
+)
+
+
+class ContractServiceDelete(orm.TransientModel):
+    _name = 'contract.service.delete'
+    _get_account_id = _get_account_id
+    _get_service_id = _get_service_id
+
+    _columns = {
+        'message': fields.text('Message'),
+        'account_id': fields.many2one('account.analytic.account', 'Account'),
+        'service_id': fields.many2one('contract.service', 'Service')
+    }
+
+    def _get_message(self, cr, uid, ids, context=None):
+        return _("When deleting a duplicate service, make sure you are "
+                 "deleting the inactive one")
+
+    _defaults = {
+        'message': _get_message,
+        'account_id': _get_account_id,
+        'service_id': _get_service_id,
+    }
+
+    def delete(self, cr, uid, ids, context=None):
+        wizard = self.browse(cr, uid, ids[0], context)
+        wizard.account_id.write({
+            'contract_service_ids': [(2, wizard.service_id.id)],
+        })
+        return True

--- a/contract_isp_unique_product/wizard/delete_contract_service.xml
+++ b/contract_isp_unique_product/wizard/delete_contract_service.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+    <record id="view_contract_service_activate" model="ir.ui.view">
+      <field name="name">Activate Service</field>
+      <field name="model">contract.service.activate</field>
+      <field name="arch" type="xml">
+        <form string="Activate Service" version="7.0">
+          <group>
+            <field name="activation_date" />
+            <field name="account_id" invisible="1" />
+            <field name="service_id" invisible="1" />
+          </group>
+          <footer>
+            <button
+              name="activate"
+              string="Activate"
+              type="object"
+              class="oe_highlight" />
+            <button
+              string="Cancel"
+              class="oe_link"
+              special="cancel" />
+          </footer>
+        </form>
+      </field>
+    </record>
+
+    <record id="view_contract_service_deactivate" model="ir.ui.view">
+      <field name="name">Deactivate Service</field>
+      <field name="model">contract.service.deactivate</field>
+      <field name="arch" type="xml">
+        <form string="Dectivate Service" version="7.0">
+          <group>
+            <field name="deactivation_date" />
+            <field name="account_id" invisible="1" />
+            <field name="service_id" invisible="1" />
+          </group>
+          <footer>
+            <button
+              name="deactivate"
+              string="Deactivate"
+              type="object"
+              class="oe_highlight" />
+            <button
+              string="Cancel"
+              class="oe_link"
+              special="cancel" />
+          </footer>
+        </form>
+      </field>
+    </record>
+    <record id="action_view_contract_service_activate" model="ir.actions.act_window">
+      <field name="name">Activate Service</field>
+      <field name="type">ir.actions.act_window</field>
+      <field name="src_model">contract.service</field>
+      <field name="res_model">contract.service.activate</field>
+      <field name="view_type">form</field>
+      <field name="view_mode">form</field>
+      <field name="context">{'default_service_id': active_id}</field>
+      <field name="target">new</field>
+    </record>
+    <record id="action_view_contract_service_deactivate" model="ir.actions.act_window">
+      <field name="name">Deactivate Service</field>
+      <field name="type">ir.actions.act_window</field>
+      <field name="src_model">contract.service</field>
+      <field name="res_model">contract.service.deactivate</field>
+      <field name="view_type">form</field>
+      <field name="view_mode">form</field>
+      <field name="context">{'default_service_id': active_id}</field>
+      <field name="target">new</field>
+    </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Not sure if this is too specific, but here goes:

This module adds a restriction on contracts (account.analytic.account) services (contract.service) so that product codes cannot be repeated.
1. Why not a constraint: To allow a smooth transition for existing data, the check is enforced when creating contracts or services, or when modifying contract services. This also prevents the new check from failing invoicing processes or anything that might write to the contract.
2. Why restrict based on product code: We use lines with a "Detail" product that may be repeated for each service/product. This allows enforcing only on actual products.
