### PR TITLE
[FIX] broken tests: leap years matter

### DIFF
--- a/contract_isp/contract.py
+++ b/contract_isp/contract.py
@@ -19,9 +19,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-
 import logging
-_logger = logging.getLogger(__name__)
 import calendar
 import datetime
 
@@ -33,6 +31,8 @@ from openerp.tools.translate import _
 LINE_TYPE_EXCEPTION = 'x'
 LINE_TYPE_RECURRENT = 'r'
 LINE_TYPE_ONETIME = 'o'
+
+_logger = logging.getLogger(__name__)
 
 
 def add_months(sourcedate, months):

--- a/contract_isp_invoice/tests/test_deactivate.py
+++ b/contract_isp_invoice/tests/test_deactivate.py
@@ -20,12 +20,16 @@
 ##############################################################################
 from __future__ import unicode_literals
 
+from calendar import monthrange
 from datetime import date
 from functools import partial
 
 from openerp.tests.common import TransactionCase
 
 from .common import ServiceSetup, YEAR
+
+
+END_FEB = monthrange(YEAR, 2)[1]  # Last day of February
 
 
 class test_prorata_deactivate_service(TransactionCase, ServiceSetup):
@@ -76,7 +80,7 @@ class test_prorata_deactivate_service(TransactionCase, ServiceSetup):
             invoice_end=(3, 31),
             expected_amount=(
                 1 +  # March,
-                self.service_obj._prorata_rate(15, 28)  # Feb 14-28 : 15 days
+                self.service_obj._prorata_rate(END_FEB - 13, END_FEB)
             ) * -56,  # Refund
         )
 
@@ -90,7 +94,7 @@ class test_prorata_deactivate_service(TransactionCase, ServiceSetup):
             invoice_end=(3, 31),
             expected_amount=(
                 1 +  # March,
-                self.service_obj._prorata_rate(15, 28)  # Feb 14-28 : 15 days
+                self.service_obj._prorata_rate(END_FEB - 13, END_FEB)
             ) * -56,  # Refund
         )
 
@@ -101,9 +105,9 @@ class test_prorata_deactivate_service(TransactionCase, ServiceSetup):
             operation_date=(2, 8),
             invoice_date=(2, 14),
             invoice_start=(2, 7),
-            invoice_end=(2, 28),
+            invoice_end=(2, END_FEB),
             expected_amount=(
-                self.service_obj._prorata_rate(22, 28)  # Feb 7-28 : 22 days
+                self.service_obj._prorata_rate(END_FEB - 6, END_FEB)
             ) * -56,  # Refund
         )
 
@@ -117,7 +121,7 @@ class test_prorata_deactivate_service(TransactionCase, ServiceSetup):
             invoice_end=(3, 31),
             expected_amount=(
                 1 +  # March
-                self.service_obj._prorata_rate(22, 28)  # Feb 7-28 : 22 days
+                self.service_obj._prorata_rate(END_FEB - 6, END_FEB)
             ) * -56,  # Refund
         )
 
@@ -130,7 +134,7 @@ class test_prorata_deactivate_service(TransactionCase, ServiceSetup):
             invoice_start=(2, 7),
             invoice_end=(2, 14),
             expected_amount=(
-                self.service_obj._prorata_rate(8, 28)  # Feb 7-14 : 8 days
+                self.service_obj._prorata_rate(8, END_FEB)  # Feb 7-14 : 8 days
             ) * 56,  # Invoice
         )
 
@@ -143,9 +147,12 @@ class test_prorata_deactivate_service(TransactionCase, ServiceSetup):
             invoice_start=(2, 7),
             invoice_end=(4, 16),
             expected_amount=(
-                self.service_obj._prorata_rate(22, 28) +  # Feb 7-28 : 22 days
-                self.service_obj._prorata_rate(16, 30) +  # Apr 1-16 : 16 days
-                1  # March
+                # From Feb 7th to end of month, so len(feb) - 6 days
+                self.service_obj._prorata_rate(END_FEB - 6, END_FEB) +
+                # Apr 1-16 : 16 days
+                self.service_obj._prorata_rate(16, 30) +
+                # All of March
+                1
             ) * 56,  # Invoice
         )
 

--- a/contract_isp_invoice/tests/test_prorata.py
+++ b/contract_isp_invoice/tests/test_prorata.py
@@ -22,10 +22,14 @@ from __future__ import unicode_literals
 
 from datetime import date
 from functools import partial
+from calendar import monthrange
 
 from openerp.tests.common import TransactionCase
 
 from .common import ServiceSetup, YEAR
+
+
+END_FEB = monthrange(YEAR, 2)[1]  # Last day of February
 
 
 class test_prorata_activate_service(TransactionCase, ServiceSetup):
@@ -50,8 +54,11 @@ class test_prorata_activate_service(TransactionCase, ServiceSetup):
             operation_date=(1, 14),
             invoice_date=(1, 7),
             invoice_start=(2, 13),
-            invoice_end=(2, 28),
-            expected_amount=self.service_obj._prorata_rate(16, 28) * 56,
+            invoice_end=(2, END_FEB),
+            expected_amount=self.service_obj._prorata_rate(
+                END_FEB - 12,  # Start on 13th, so bill [(28 or 29) - 12] days
+                END_FEB  # 28 or 29 days in the month, depending
+            ) * 56,
         )
 
     def test_prorata_after_invoice_before_cutoff_past_month(self):
@@ -84,8 +91,11 @@ class test_prorata_activate_service(TransactionCase, ServiceSetup):
             operation_date=(1, 26),
             invoice_date=(2, 7),
             invoice_start=(2, 15),
-            invoice_end=(2, 28),
-            expected_amount=self.service_obj._prorata_rate(14, 28) * 56,
+            invoice_end=(2, END_FEB),
+            expected_amount=self.service_obj._prorata_rate(
+                END_FEB - 14,  # Start on 15th, so bill [(28 or 29) - 14] days
+                END_FEB  # 28 or 29 days in the month, depending
+            ) * 56,
         )
 
     def test_prorata_before_invoice_past_month_activation(self):
@@ -102,8 +112,11 @@ class test_prorata_activate_service(TransactionCase, ServiceSetup):
             operation_date=(2, 1),
             invoice_date=(2, 7),
             invoice_start=(2, 27),
-            invoice_end=(2, 28),
-            expected_amount=self.service_obj._prorata_rate(2, 28) * 56,
+            invoice_end=(2, END_FEB),
+            expected_amount=self.service_obj._prorata_rate(
+                END_FEB - 26,  # 2 or 3 days, depending on leap year
+                END_FEB  # 28 or 29 days
+            ) * 56,
         )
 
     def test_prorata_before_invoice_current_month_activation(self):
@@ -135,7 +148,7 @@ class test_prorata_activate_service(TransactionCase, ServiceSetup):
                            operation_date=(2, 5),
                            invoice_date=(2, 7),
                            invoice_start=(2, 1),
-                           invoice_end=(2, 28),
+                           invoice_end=(2, END_FEB),  # 28 or 29 (leap years)
                            expected_amount=56)
 
     def _test_invoice(self, product,


### PR DESCRIPTION
Some tests were failing because the last day of February was hardcoded as 28.

The invoicing system correctly handles leap years, but the tests don't, causing a mismatch in test results.
