### PR TITLE
[IMP] Equipment ID Missing

### DIFF
--- a/connector_equipment_service/models/agreement_serviceprofile.py
+++ b/connector_equipment_service/models/agreement_serviceprofile.py
@@ -8,6 +8,8 @@ from odoo import _, api, models
 class AgreementServiceProfile(models.Model):
     _inherit = ['agreement.serviceprofile']
 
+    equipment_id = fields.Many2one('maintenance.equipment', "Equipment ID")
+
     @api.multi
     def write(self, vals):
         # If equipment was empty and now set to managed equipment


### PR DESCRIPTION
At some point before the PR #32 was merged "equipment_id" was removed, this PR adds it back